### PR TITLE
Refactor extract_gene_ids App, add correctedness test

### DIFF
--- a/gfam/scripts/extract_gene_ids.py
+++ b/gfam/scripts/extract_gene_ids.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import sys
 
-from gfam import fasta
 from gfam.scripts import CommandLineApp
-from gfam.utils import open_anything
+from gfam.tasks.extract_gene_ids.task import ExtractGeneIDsTask
 
 __author__ = "Tamas Nepusz"
 __email__ = "tamas@cs.rhul.ac.uk"
@@ -19,6 +17,9 @@ class ExtractGeneIDsApp(CommandLineApp):
 
     Extracts the gene IDs from a FASTA file.
     """
+
+    def __init__(self):
+        self.task = ExtractGeneIDsTask()
 
     def create_parser(self):
         """Creates the command line parser for this application"""
@@ -37,17 +38,8 @@ class ExtractGeneIDsApp(CommandLineApp):
             infiles = self.args
 
         for infile in infiles:
-            self.process_file(infile)
-
-    def process_file(self, filename):
-        """Processes the given input file"""
-        self.log.info("Processing %s..." % filename)
-
-        parser = fasta.Parser(open_anything(filename))
-        parser = fasta.regexp_remapper(parser,
-                                       self.options.sequence_id_regexp)
-        for seq in parser:
-            print(seq.id)
+            self.task.process_file(infile,
+                                   self.options.sequence_id_regexp)
 
 
 if __name__ == "__main__":

--- a/gfam/tasks/base.py
+++ b/gfam/tasks/base.py
@@ -1,0 +1,11 @@
+import logging
+
+
+class LoggedTask:
+    def __init__(self, logger: logging.Logger = None):
+        if logger is None:
+            self.log = logging.getLogger(__file__)
+            self.log.setLevel(logging.DEBUG)
+            logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+        else:
+            self.log = logger

--- a/gfam/tasks/extract_gene_ids/task.py
+++ b/gfam/tasks/extract_gene_ids/task.py
@@ -1,0 +1,15 @@
+from gfam import fasta
+from gfam.tasks.base import LoggedTask
+from gfam.utils import open_anything
+
+
+class ExtractGeneIDsTask(LoggedTask):
+    def process_file(self, filename: str, sequence_id_regexp: str):
+        """Processes the given input file"""
+        self.log.info("Processing %s..." % filename)
+
+        parser = fasta.Parser(open_anything(filename))
+        parser = fasta.regexp_remapper(parser,
+                                       sequence_id_regexp)
+        for seq in parser:
+            print(seq.id)

--- a/gfam/tasks/find_unassigned/task.py
+++ b/gfam/tasks/find_unassigned/task.py
@@ -4,28 +4,24 @@ from typing import Dict
 from gfam import fasta
 from gfam.assignment import AssignmentOverlapChecker, SequenceWithAssignments
 from gfam.interpro import AssignmentReader
+from gfam.tasks.base import LoggedTask
 from gfam.tasks.find_unassigned.intervals import substract
 from gfam.tasks.find_unassigned.low_complexity_regions import \
     read_low_complexity_regions
 from gfam.utils import open_anything
 
 
-class FindUnassignedTask:
+class FindUnassignedTask(LoggedTask):
     def __init__(self,
                  max_overlap: int,
                  min_fragment_length: int,
                  min_length: int,
                  sequence_id_regexp: str = None,
                  logger: logging.Logger = None):
+        super().__init__(logger)
         AssignmentOverlapChecker.max_overlap = max_overlap
         self.min_fragment_length = min_fragment_length
         self.min_length = min_length
-        if logger is None:
-            self.log = logging.getLogger(__file__)
-            self.log.setLevel(logging.DEBUG)
-            logging.basicConfig(level=logging.DEBUG, format="%(message)s")
-        else:
-            self.log = logger
         self.sequence_id_regexp = sequence_id_regexp
 
         # these are moved here from get_unassigned

--- a/test/fixtures/find_unassigned_fixtures.py
+++ b/test/fixtures/find_unassigned_fixtures.py
@@ -19,7 +19,7 @@ class FindUnassignedFixture:
     def get_low_complexity_regions_file(self) -> str:
         return os.path.join(self.data_dir, "uniprot_sprot100.mask")
 
-    def _get_fasta_file(self) -> str:
+    def get_fasta_file(self) -> str:
         return os.path.join(self.data_dir, "uniprot_sprot100.fasta")
 
     def _get_expected_output_file(self) -> str:
@@ -35,7 +35,7 @@ class FindUnassignedFixture:
 
     def get_default_args_for_app(self) -> List[str]:
         assignments_file = self.get_assignment_file()
-        fasta_file = self._get_fasta_file()
+        fasta_file = self.get_fasta_file()
         seg_file = self.get_low_complexity_regions_file()
 
         args = [assignments_file,

--- a/test/unit/gfam/tasks/extract_gene_ids/test_extract_gene_ids_task.py
+++ b/test/unit/gfam/tasks/extract_gene_ids/test_extract_gene_ids_task.py
@@ -1,0 +1,38 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from test.fixtures.find_unassigned_fixtures import FindUnassignedFixture
+from typing import List
+
+from gfam.tasks.extract_gene_ids.task import ExtractGeneIDsTask
+
+
+class TestExtractGeneIDsTask(unittest.TestCase):
+    def setUp(self):
+        fixture = FindUnassignedFixture()
+        self.fasta_file = fixture.get_fasta_file()
+        self._sut = ExtractGeneIDsTask()
+
+    def _get_obtained_output(self) -> List[str]:
+        output = io.StringIO()
+        # obtain output from find_unassigned and print it to a
+        # string stream
+        with redirect_stdout(output):
+            self._sut.process_file(self.fasta_file,
+                                   r"(\w+\|)(?P<id>\w+)(\|\w+)+")
+        # rewind to allow reading it from the beginning
+        output.seek(0)
+        obtained_prot_ids = [x.strip() for x in output]
+        return obtained_prot_ids
+
+    def test_output_should_be_correct(self):
+        # arrange
+        expected_output = [x.strip().split("|")[1]
+                           for x in open(self.fasta_file)
+                           if x and x.startswith(">")]
+
+        # act
+        obtained_output = self._get_obtained_output()
+
+        # assert
+        self.assertEqual(expected_output, obtained_output)


### PR DESCRIPTION
Very simple PR:

(1) It breaks extract_gene_ids into the App (again, responsible for catching and processing the parameters), and the Task (responsible for the processing).
(2) I have created the base `LoggedTask` class to add a logger in the constructor, with a default logger if none passed. I have modified the `FindUnassignedTask` class accordingly to avoid code duplications.
(3) The class `ExtractGeneIdsTask` is now unit tested.
(4) There is a minimal change to the `FindUnassignedFixture` to change a private method into a public one to allow access to the FASTA file name.